### PR TITLE
Loze ruimte informatiescherm opgevangen

### DIFF
--- a/Objecten.pyw
+++ b/Objecten.pyw
@@ -87,8 +87,10 @@ class Doek(tkinter.Canvas):
             i.teken(zelf)
         if informatieweergeven:
             zelf.create_text(5, 0, text = "Snelheden:", fill = "black", font = "-size 30", anchor="nw")
+            positieteller = 0
             for robot in robots:
-                zelf.create_text(5, robot.id*40+40, text=robot.kleur[0].upper() + robot.kleur[1:] + ": " + str(round(math.sqrt((speler.snelheid_x - robot.snelheid_x) ** 2 + (speler.snelheid_y - robot.snelheid_y) ** 2))), fill=robot.kleur, font="-size 30", anchor="nw")
+                zelf.create_text(5, positieteller*40+40, text=robot.kleur[0].upper() + robot.kleur[1:] + ": " + str(round(math.sqrt((speler.snelheid_x - robot.snelheid_x) ** 2 + (speler.snelheid_y - robot.snelheid_y) ** 2))), fill=robot.kleur, font="-size 30", anchor="nw")
+                positieteller += 1
 
     def far_away(zelf, robot, x, y):
                 zelf.create_text(5, 0 + 40 * robot.id, text = robot.kleur[0].upper() + robot.kleur[1:] + ": " + str(round(math.sqrt((speler.snelheid_x - robot.snelheid_x)**2 + (speler.snelheid_y - robot.snelheid_y)**2))), fill = robot.kleur, font = "-size 30", anchor="nw")


### PR DESCRIPTION
De loze ruimte die ontstaat in het snelheidsinformatiescherm bij het verwijderen van een robot opgevangen door aanwezige robots te tellen i.p.v. het robot-identificatienummer te gebruiken.
